### PR TITLE
fix: send back 400 status code on bad requests

### DIFF
--- a/server/endpoint.go
+++ b/server/endpoint.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	"github.com/go-kit/kit/log"
 	httptransport "github.com/go-kit/kit/transport/http"
-	"github.com/pkg/errors"
 )
 
 // possible SCEP operations
@@ -144,7 +143,7 @@ func MakeSCEPEndpoint(svc Service) endpoint.Endpoint {
 		case "PKIOperation":
 			resp.Data, resp.Err = svc.PKIOperation(ctx, req.Message)
 		default:
-			return nil, errors.New("operation not implemented")
+			return nil, &BadRequestError{Message: "operation not implemented"}
 		}
 		return resp, nil
 	}

--- a/server/service.go
+++ b/server/service.go
@@ -72,6 +72,9 @@ func (svc *service) GetCACert(ctx context.Context, _ string) ([]byte, int, error
 }
 
 func (svc *service) PKIOperation(ctx context.Context, data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, &BadRequestError{Message: "missing data for PKIOperation"}
+	}
 	msg, err := scep.ParsePKIMessage(data, scep.WithLogger(svc.debugLogger))
 	if err != nil {
 		return nil, err

--- a/server/transport_test.go
+++ b/server/transport_test.go
@@ -186,6 +186,18 @@ func TestInvalidReqs(t *testing.T) {
 	if resp.StatusCode != 400 {
 		t.Error("expected", http.StatusBadRequest, "got", resp.StatusCode)
 	}
+
+	params = req.URL.Query()
+	params.Set("operation", "InvalidOperation")
+	req.URL.RawQuery = params.Encode()
+
+	resp, err = http.DefaultClient.Do(postReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 400 {
+		t.Error("expected", http.StatusBadRequest, "got", resp.StatusCode)
+	}
 }
 
 func newServer(t *testing.T, opts ...scepserver.ServiceOption) (*httptest.Server, scepserver.Service, func()) {

--- a/server/transport_test.go
+++ b/server/transport_test.go
@@ -123,6 +123,71 @@ func TestPKIOperationGET(t *testing.T) {
 	}
 }
 
+func TestInvalidReqs(t *testing.T) {
+	server, _, teardown := newServer(t)
+	defer teardown()
+	// Check that invalid requests return status 400.
+	req, err := http.NewRequest("GET", server.URL+"/scep", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 400 {
+		t.Error("expected", http.StatusBadRequest, "got", resp.StatusCode)
+	}
+
+	req, err = http.NewRequest("GET", server.URL+"/scep", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	params := req.URL.Query()
+	params.Set("operation", "PKIOperation")
+	params.Set("message", "")
+	req.URL.RawQuery = params.Encode()
+
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 400 {
+		t.Error("expected", http.StatusBadRequest, "got", resp.StatusCode)
+	}
+
+	params = req.URL.Query()
+	params.Set("operation", "InvalidOperation")
+	req.URL.RawQuery = params.Encode()
+
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 400 {
+		t.Error("expected", http.StatusBadRequest, "got", resp.StatusCode)
+	}
+
+	postReq, err := http.NewRequest("POST", server.URL+"/scep", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	params = req.URL.Query()
+	params.Set("operation", "PKIOperation")
+	req.URL.RawQuery = params.Encode()
+
+	resp, err = http.DefaultClient.Do(postReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 400 {
+		t.Error("expected", http.StatusBadRequest, "got", resp.StatusCode)
+	}
+}
+
 func newServer(t *testing.T, opts ...scepserver.ServiceOption) (*httptest.Server, scepserver.Service, func()) {
 	var err error
 	var depot depot.Depot // cert storage


### PR DESCRIPTION
> Related issue: https://github.com/fleetdm/fleet/issues/15635

- Allow caller to set handler path on scepserver.MakeHTTPHandler
- fix: return bad request errors when requests fail validation
- feat: some tests
